### PR TITLE
Big rename from Panoramix to Katzenpost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 
-The Panoramix Decryption Mix Network Design and Specification Documents
-=======================================================================
+The Katzenpost Decryption Mix Network Design and Specification Documents
+========================================================================
 
 license
 =======

--- a/drafts/mixdesign.txt
+++ b/drafts/mixdesign.txt
@@ -1,4 +1,4 @@
-The Panoramix Decryption Mix Network Anonymity System:
+The Katzenpost Decryption Mix Network Anonymity System:
 fast, safe and correct mixnet protocol design
 
 Yawning Angel
@@ -13,7 +13,7 @@ Version 0
 Abstract
 
 This document describes the high level architecture and design of the
-Panoramix Decryption Mix Network. Here we also present a novel
+Katzenpost Decryption Mix Network. Here we also present a novel
 multidisciplinary approach to mix network protocol design which
 introduces design ideas from the packet switching network literature
 used in concert with the latest innovations in mix network design from
@@ -113,7 +113,7 @@ receive POP3 proxy designs, however we've also specified the design
 of an existing e-mail software with user interaction design modifications
 suited for our end to end mixnet messaging protocol:
 
-"Panoramix Decryption Mix Network User Interface Design"
+"Katzenpost Decryption Mix Network User Interface Design"
 
 
 Layers of Mix Network Encryption
@@ -126,7 +126,7 @@ Layers of Mix Network Encryption
   crypto is post-quantum and uses
   Noise_NNhfs_25519+NewHope-Simple_ChaChaPoly_Blake2b, described in:
 
-     "Panoramix Mix Network Wire Protocol Specification".
+     "Katzenpost Mix Network Wire Protocol Specification".
 
 * mix packets - The Sphinx mix cryptographic packet format is used to
   send mix network messages. Our implementation uses X25519,
@@ -138,7 +138,7 @@ Layers of Mix Network Encryption
   by mix network Clients using Noise_X_25519_ChaChaPoly_Blake2b,
   a one-way Noise framework pattern. [NOISE17] Details can be found in:
 
-     "Panoramix Mix Network End-to-end Protocol Specification".
+     "Katzenpost Mix Network End-to-end Protocol Specification".
 
 
 The Poisson Stop and Wait Automatic Repeat Request Protocol

--- a/drafts/user_interface.txt
+++ b/drafts/user_interface.txt
@@ -1,4 +1,4 @@
-Panoramix Decryption Mix Network User Interface Design
+Katzenpost Decryption Mix Network User Interface Design
 Yawning Angel
 Claudia Diaz
 David Stainton
@@ -7,7 +7,7 @@ Version 0
 
 Abstract
 
-   This document describes the user interface design of the Panoramix
+   This document describes the user interface design of the Katzenpost
    mix network.
 
 1. Introduction
@@ -82,7 +82,7 @@ Abstract
    key-pairs. The sender identity is specified in the mail header
    field like so:
 
-      X-Panoramix-Sender-Identity-Key: <base64 X25519 key>
+      X-Katzenpost-Sender-Identity-Key: <base64 X25519 key>
 
 Appendix A. References
 

--- a/specs/end_to_end.txt
+++ b/specs/end_to_end.txt
@@ -1,4 +1,4 @@
-Panoramix Mix Network End-to-end Protocol Specification
+Katzenpost Mix Network End-to-end Protocol Specification
 Yawning Angel
 George Danezis
 Claudia Diaz
@@ -9,11 +9,11 @@ Version 0
 
 Abstract
 
-   This is a specification for the Panoramix/LEAP mix network client
+   This is a specification for the Katzenpost/LEAP mix network client
    end to end protocol and egress mix behavior. The mix network
-   specification is described in Panoramix Mix Network Specification.
+   specification is described in Katzenpost Mix Network Specification.
    The protocols used by the entities to publish their identities is
-   described in the Panoramix Mix Network PKI Specification.
+   described in the Katzenpost Mix Network PKI Specification.
 
 Table of Contents
 
@@ -98,7 +98,7 @@ Table of Contents
      behalf of the user. Provider MUST perform the same cryptographic
      operations as the Mix.
 
-   * Packet - A Sphinx packet.The Panoramix system supports multiple
+   * Packet - A Sphinx packet.The Katzenpost system supports multiple
               packet sizes for different classes of traffic. In particular:
 	      * XKB-block: XX KB (to-do: specify the number of KB)
 	      * YKB-block: YY KB (to-do: specify the number of KB/MB)
@@ -135,15 +135,15 @@ Table of Contents
    "Sphinx Mix Network Cryptographic Packet Format Specification"
 
    The Sphinx cryptographic primitives and parameters are specified in
-   Section 3 of: "The Panoramix Mix Network Specification"
+   Section 3 of: "The Katzenpost Mix Network Specification"
 
 3. Client and Provider Core Protocol
 
    All client mixnet interaction happens through their Provider,
    reusing the existing trust relationship any given user may have
    with an e-mail service provider, and all client to Provider
-   interaction will use the Panoramix Mix Network Wire Protocol,
-   described in “Panoramix Mix Network Wire Protocol Specification”.
+   interaction will use the Katzenpost Mix Network Wire Protocol,
+   described in “Katzenpost Mix Network Wire Protocol Specification”.
 
 3.1 Handshake and Authentication
 
@@ -534,7 +534,7 @@ Table of Contents
 
    (XXX/ya: Should we mandate that clients insert something like:
 
-    `X-Panoramix-Sender: <Base64(s)>` as a header?
+    `X-Katzenpost-Sender: <Base64(s)>` as a header?
    )
 
 4.2.2 Client Protocol Acknowledgment Processing (SURB-ACKs).
@@ -613,7 +613,7 @@ Table of Contents
    of randomly selected mixes. The sequence of mixes is chosen independently
    for each Block.
 
-   Panoramix uses the Layered topology, thus the selected path MUST
+   Katzenpost uses the Layered topology, thus the selected path MUST
    contain one and only one mix per layer, and MUST traverse all layers.
    Within a layer, the mix is selected with probability proportional to
    its bandwidth/capacity. Thus, if a mix has a fraction f of the total
@@ -670,12 +670,12 @@ Table of Contents
 
    Clients download Mix Descriptors from the PKI, also known as the
    Mix Directory Authority service.  More details about the PKI system
-   and the Mix Descriptors can be found in the Panoramix Mix Network
+   and the Mix Descriptors can be found in the Katzenpost Mix Network
    PKI Specification.
 
    Clients will have the following information available to them:
 
-      * Panoramix Mix Network Parameters via the PKI:
+      * Katzenpost Mix Network Parameters via the PKI:
          * topology information,
          * packet sizes for different classes of traffic,
          * parameter of the exponential delay (lambda) for Poisson mix
@@ -684,7 +684,7 @@ Table of Contents
 	 * the list of public keys and addresses of the active mixes,
 
       * Mix Network Consensus Document containing Mix Descriptors as
-        described in the Panoramix Mix Network PKI Specification
+        described in the Katzenpost Mix Network PKI Specification
 
       * Current mix network time via Rough Time protocol with mixes
 

--- a/specs/mixnet.txt
+++ b/specs/mixnet.txt
@@ -1,4 +1,4 @@
-Panoramix Mix Network Specification
+Katzenpost Mix Network Specification
 Yawning Angel
 George Danezis
 Claudia Diaz
@@ -11,7 +11,7 @@ Abstract
 
    This document describes the high level architecture and detailed
    protocols and behavior required of mix nodes participating in the
-   Panoramix Mix Network.
+   Katzenpost Mix Network.
 
 Table of Contents
 
@@ -64,12 +64,12 @@ Table of Contents
 
    Node - A Mix or Provider instance.
 
-   User - An agent using the Panoramix system.
+   User - An agent using the Katzenpost system.
 
    Client - Software run by the User on its local device to
             participate in the Mixnet.
 
-   Panoramix - A project to design an improved mix service as described
+   Katzenpost - A project to design an improved mix service as described
                in this specification. Also, the name of the reference
                software to implement this service, currently under
                development.
@@ -80,7 +80,7 @@ Table of Contents
                         * Large messages (big attachments)
                         /* This may be changed after we do our analysis on the stats */
 
-   Packet - A string transmitted anonymously thought the Panoramix network.
+   Packet - A string transmitted anonymously thought the Katzenpost network.
              The length of the packet is fixed for every class of traffic.
 
    Payload - The [xxx] KiB portion of a Packet containing a message,
@@ -90,7 +90,7 @@ Table of Contents
    Message - A variable-length sequence of octets sent anonymously
              through the network. Short messages are sent in a single
              packet; long messages are fragmented across multiple
-             packets (see the Panoramix Mix Network End-to-end
+             packets (see the Katzenpost Mix Network End-to-end
              Protocol Specification for more information about
              encoding messages into payloads). /*<- This has to be rephrased after
              The analysis of the stats; if we have multiple classes of traffic */
@@ -108,7 +108,7 @@ Table of Contents
    The presented system design is based on [LOOPIX]. The detailed
    End-to-end specification, describing the operations performed
    By the sender and recipient, as well sender’s provider and
-   Recipient’s provider, are presented in “Panoramix Mix Network
+   Recipient’s provider, are presented in “Katzenpost Mix Network
    End-to-end Protocol Specification”. Below, we present the system overview.
 
    The Provider ran by each service provider is responsible for
@@ -176,7 +176,7 @@ Table of Contents
 
 2.2. Network Topology
 
-   The Panoramix Mix Network uses a layered topology consisting of a
+   The Katzenpost Mix Network uses a layered topology consisting of a
    fixed number of layers, each containing a set of mixes. At any
    given time each Mix MUST only be assigned to one specific layer.
    Each Mix in a given layer N is connected to every other Mix in
@@ -223,13 +223,13 @@ Table of Contents
 
    "The Sphinx Mix Network Cryptographic Packet Format Specification"
 
-   As the Sphinx packet format is generic, the Panoramix Mix Network
+   As the Sphinx packet format is generic, the Katzenpost Mix Network
    must provide a concrete instantiation of the format, as well as
    additional Sphinx per-hop routing information commands.
 
 3.1 Sphinx Cryptographic Primitives
 
-   For the current version of the Panoramix Mix Network, let the
+   For the current version of the Katzenpost Mix Network, let the
    following cryptographic primitives be used as described in the
    Sphinx specification.
 
@@ -260,7 +260,7 @@ Table of Contents
 
 3.2 Sphinx Packet Parameters
 
-   The following parameters are used as for the Panoramix Mix Network
+   The following parameters are used as for the Katzenpost Mix Network
    instantiation of the Sphinx Packet Format:
 
     * AD_SIZE            - 2 bytes.
@@ -290,7 +290,7 @@ Table of Contents
       struct {
           uint8_t version;  /* 0x00 */
           uint8_t reserved; /* 0x00 */
-      } PanoramixAdditionalData;
+      } KatzenpostAdditionalData;
 
       (XXX/ya: Double check to ensure that this causes the rest of the packet
        header to be 4 byte aligned, when wrapped in the wire protocol command
@@ -319,7 +319,7 @@ Table of Contents
 
       enum {
           mix_delay(0x80),
-      } PanoramixCommandType;
+      } KatzenpostCommandType;
 
    The mix_delay command structure is as follows:
 
@@ -351,8 +351,8 @@ Table of Contents
 
 4.1 Link Layer Connection Management
 
-   All communication to and from participants in the Panoramix Mix
-   Network is done via the Panoramix Mix Network Wire Protocol [PANMIXWIRE].
+   All communication to and from participants in the Katzenpost Mix
+   Network is done via the Katzenpost Mix Network Wire Protocol [KATZMIXWIRE].
 
    Nodes are responsible for establishing the connection to the next
    hop, for example, a mix in layer 0 will accept inbound connections
@@ -390,7 +390,7 @@ Table of Contents
 
    Each Node MUST rotate the key pair used for Sphinx packet processing
    periodically for forward secrecy reasons and to keep the list of seen
-   packet tags short. The Panoramix Mix Network uses a fixed interval
+   packet tags short. The Katzenpost Mix Network uses a fixed interval
    (epoch), so that key rotations happen simultaneously throughout
    the network, at predictable times.
 
@@ -573,7 +573,7 @@ Appendix A.1 Normative References
                for Security", RFC 7748, January 2016.
 
    (XXX/david: fix this reference, add author names and url)
-   [PANMIXWIRE] "Panoramix Mix Network Wire Protocol Specification", June 2017.
+   [KATZMIXWIRE] "Katzenpost Mix Network Wire Protocol Specification", June 2017.
 
 A.2 Informative References
 

--- a/specs/pki.txt
+++ b/specs/pki.txt
@@ -1,4 +1,4 @@
-Panoramix Mix Network Public Key Infrastructure Specification
+Katzenpost Mix Network Public Key Infrastructure Specification
 Yawning Angel
 Ania Piotrowska
 David Stainton
@@ -73,8 +73,8 @@ Table of Contents
    and bridging attacks [FINGERPRINTING] [BRIDGING] [LOCALVIEW].
 
    The PKI is also used by Authority operators to specify network-wide
-   parameters, for example in the Panoramix Decryption Mix Network
-   [PANMIXNET] the Poisson mix strategy is used and therefore all the
+   parameters, for example in the Katzenpost Decryption Mix Network
+   [KATZMIXNET] the Poisson mix strategy is used and therefore all the
    clients must use the same lambda parameter for their exponential
    distribution function when choosing hop delays in the path
    selection. The Mix Network Directory Authority system aka PKI
@@ -103,7 +103,7 @@ Table of Contents
             path selection algorithm.
 
    nickname - simply a nickname string that is unique in the consensus
-              document; see "Panoramix Mix Network Specification"
+              document; see "Katzenpost Mix Network Specification"
               section "2.2. Network Topology".
 
    layer - The layer indicates which network topology layer a
@@ -120,7 +120,7 @@ Table of Contents
 
    Each Mix MUST rotate the key pair used for Sphinx packet processing
    periodically for forward secrecy reasons and to keep the list of
-   seen packet tags short. [SPHINX09] [SPHINXSPEC] The Panoramix Mix
+   seen packet tags short. [SPHINX09] [SPHINXSPEC] The Katzenpost Mix
    Network uses a fixed interval (epoch), so that key rotations happen
    simultaneously throughout the network, at predictable times.
 
@@ -415,7 +415,7 @@ Table of Contents
      If a passive network adversary can watch the Directory Authority
      servers vote, that's OK. However, very paranoid implementers
      could disagree and use our Noise based PQ crypto wire protocol
-     [PANMIXWIRE] for Directory Authority system message exchange as
+     [KATZMIXWIRE] for Directory Authority system message exchange as
      was suggested in section "6. Future Work".
 
    * Constructing this consensus protocol using a cryptographically
@@ -461,8 +461,8 @@ Appendix A.2 Informative References
                "Local View Attack on Anonymous Communication",
                <https://www.freehaven.net/anonbib/cache/esorics05-Klonowski.pdf>.
 
-   [PANMIXNET]  Angel, Y., Danezis, G., Diaz, C., Piotrowska, A., Stainton, D.,
-                "Panoramix Mix Network Specification", June 2017,
+   [KATZMIXNET]  Angel, Y., Danezis, G., Diaz, C., Piotrowska, A., Stainton, D.,
+                "Katzenpost Mix Network Specification", June 2017,
                 <https://github.com/Katzenpost/docs/blob/master/specs/mixnet.txt>.
 
    [SPHINX09]  Danezis, G., Goldberg, I., "Sphinx: A Compact and
@@ -491,5 +491,5 @@ Appendix A.2 Informative References
                "The Structure of Authority: Why Security Is not a Separable Concern",
                <http://www.erights.org/talks/no-sep/secnotsep.pdf>.
 
-   [PANMIXWIRE] Angel, Y. "Panoramix Mix Network Wire Protocol Specification", June 2017,
+   [KATZMIXWIRE] Angel, Y. "Katzenpost Mix Network Wire Protocol Specification", June 2017,
                 <https://github.com/Katzenpost/docs/blob/master/specs/wire-protocol.txt>.

--- a/specs/wire-protocol.txt
+++ b/specs/wire-protocol.txt
@@ -1,12 +1,12 @@
-Panoramix Mix Network Wire Protocol Specification
+Katzenpost Mix Network Wire Protocol Specification
 Yawning Angel
 
 Version 0
 
 Abstract
 
-   This document defines the Panoramix Mix Network Wire Protocol for
-   use in all network communications to, from, and within the Panoramix
+   This document defines the Katzenpost Mix Network Wire Protocol for
+   use in all network communications to, from, and within the Katzenpost
    Mix Network.
 
 Table of Contents
@@ -32,9 +32,9 @@ Table of Contents
 
 1. Introduction
 
-   The Panoramix Mix Network Wire Protocol (PMNWP) is the custom wire
+   The Katzenpost Mix Network Wire Protocol (KMNWP) is the custom wire
    protocol for all network communications to, from, and within the
-   Panoramix Mix Network. This protocol provides mutual authentication,
+   Katzenpost Mix Network. This protocol provides mutual authentication,
    and an additional layer of cryptographic security and forward
    secrecy.
 
@@ -89,7 +89,7 @@ Table of Contents
 
      FFLEN = 32
 
-   It is assumed that all parties using the PMNWP protocol have a fixed
+   It is assumed that all parties using the KMNWP protocol have a fixed
    long lived X25519 keypair [RFC7748], the public component of which
    is known to the other party in advance.  How such keys are distributed
    is beyond the scope of this document.
@@ -177,9 +177,9 @@ Table of Contents
 
    Upon successfully concluding the handshake the session enters the
    Data Transfer Phase, where the initiator and responder can exchange
-   PMNWP messages.
+   KMNWP messages.
 
-   A PMNWP message is defined to be the following structure:
+   A KMNWP message is defined to be the following structure:
 
       enum {
           no_op(0),
@@ -285,8 +285,8 @@ Table of Contents
 4. Anonymity Considerations
 
    Adversaries being able to determine that two parties are
-   communicating via PMNWP is beyond the threat model of this protocol.
-   At a minimum, it is trivial to determine that a PMNWP handshake is
+   communicating via KMNWP is beyond the threat model of this protocol.
+   At a minimum, it is trivial to determine that a KMNWP handshake is
    being performed, due to the length of each handshake message, and
    the fixed positions of the various public keys.
 


### PR DESCRIPTION
The Panoramix research project actually has 3 mixnet designs, one for statistics, one for voting, and one for messaging, this one. We should rename our design to something else to be less confusing. I suggest we simply pick Katzenpost for the design/specs as well, so here's a pull request that changes all occurrences in the spec from "Panoramix" to "Katzenpost", and renames the "Panoramix Mix Network Wire Protocol (PMNWP)" to "Katzenpost Mix Network Wire Protocol (KMNWP)".