### PR TITLE
Rebased srv spec

### DIFF
--- a/specs/pki.rst
+++ b/specs/pki.rst
@@ -306,6 +306,9 @@ Version 0
    examines it for new descriptors and includes any valid descriptors
    in its view of the network.
 
+   Each Authority includes in its vote a hashed value committing to a choice of
+   a random number for the vote. See section 4.3 for more details.
+
 3.2.1 Voting Wire Protocol Commands
 
    The Katzenpost Wire Protocol as described in [KATZMIXWIRE] is used
@@ -571,6 +574,29 @@ Version 0
        "Topology" : [],
        "Providers" : [],
    }
+
+4.3 Shared Random Value structure
+---------------------------------
+
+Katzenpost's Shared Random Value computation is inspired by Tor's Shared Random Subsystem [TORSRV].
+
+Each voting round a commit value is included in the votes sent to other authorities. These are produced as follows:
+   H = SHA3-256
+
+   COMMIT = Uint64(epoch) | H(REVEAL)
+   REVEAL = Uint64(epoch) | H(RN)
+
+After the votes are collected from the voting round, and before signature exchange, the Shared Random Value field of the consensus document is the output of H over the input string calculated as follows:
+
+  1. Validated Reveal commands received including the authorities own reveal
+       are sorted by reveal value in ascending order and appended to the input
+       in format IdentityPublicKeyBytes_n | RevealValue_n
+
+  2. If a SharedRandomValue for the previous epoch exists, it is appended to
+       the input string, otherwise 32 NUL (\x00) bytes are used.
+
+  REVEALS = ID_a | R_a | ID_b | R_b | ...
+  SharedRandomValue = H("shared-random" | Uint64(epoch) | REVEALS | PREVIOUS_SRV)
 
 5. PKI Wire Protocol
 ====================

--- a/specs/pki.rst
+++ b/specs/pki.rst
@@ -341,8 +341,10 @@ Version 0
    The epoch_number field is used by the receiving party to quickly
    check the epoch for the vote before deserializing the payload.
 
-   // TODO: each authority must include its commit value for the
-   // shared random computation in this phase along with its signed vote.
+   Each authority MUST include its commit value for the
+   shared random computation in this phase along with its signed vote.
+   This computation is derived from the Tor Shared Random Subsystem,
+   [TORSRV].
 
 3.2.3 The vote_status Command
 

--- a/specs/pki.rst
+++ b/specs/pki.rst
@@ -208,15 +208,18 @@ Version 0
 -----------------------------------------
 
    Directory Authority server interactions are conducted according to
-   the following schedule, where ``T`` is the beginning of the current epoch.
+   the following schedule, where ``T`` is the beginning of the current epoch,
+   and ``P`` is the length of the epoch period.
 
    ``T``                         - Epoch begins
 
-   ``T + 2 hours``               - Vote exchange
+   ``T + P/2``                   - Vote exchange
 
-   ``T + 2 hours + 7.5 minutes`` - Tabulation and signature exchange
+   ``T + (5/8)*P``               - Reveal exchange
 
-   ``T + 2 hours + 15 minutes``  - Publish consensus
+   ``T + (6/8)*P``               - Tabulation and signature exchange
+
+   ``T + (7/8)*P``               - Publish consensus
 
 
 2.1.2 Mix Schedule
@@ -225,26 +228,26 @@ Version 0
    Mix PKI interactions are conducted according to the following
    schedule, where T is the beginning of the current epoch.
 
-    ``T + 2 hours``              - Deadline for publication of all mixes documents
+    ``T + P/2``            - Deadline for publication of all mixes documents
                                for the next epoch.
 
-    ``T + 2 hours + 15 min``     - This marks the beginning of the period
+    ``T + (7/8)*P``        - This marks the beginning of the period
                                where mixes perform staggered fetches
                                of the PKI consensus document.
 
-    ``T + 2 hours + 30 min``     - Start establishing connections to the new set of
+    ``T + (8/9)*P``        - Start establishing connections to the new set of
                                relevant mixes in advance of the next epoch.
 
-    ``T + 3 hours - 1MSL``       - Start accepting new Sphinx packets encrypted to
+    ``T + P - 1MSL``       - Start accepting new Sphinx packets encrypted to
                                the next epoch's keys.
 
-    ``T + 3 hours + 1MSL``       - Stop accepting new Sphinx packets encrypted to
+    ``T + P + 1MSL``       - Stop accepting new Sphinx packets encrypted to
                                the previous epoch's keys, close connections to
                                peers no longer listed in the PKI documents and
                                erase the list of seen packet tags.
 
-   As it stands, mixes have ~2 hours to publish, the PKI has 15 mins
-   to vote, and the mixes have 28 mins to establish connections before
+   As it stands, mixes have ~1.5 hours to publish, the PKI has ~1 hour 
+   to vote, and the mixes have 20 mins to establish connections before
    there is network connectivity failure.
 
    Mix layer changes are controlled by the Directory Authorities and


### PR DESCRIPTION
This PR adds the SRV specification to pki.rst but omits adding tor's specification directly into our repository as we reference it by link in the references section.